### PR TITLE
Export Polygon class

### DIFF
--- a/main.js
+++ b/main.js
@@ -263,6 +263,7 @@ function Stage(core) {
 exports.Rect = amino.Rect;
 exports.Group = amino.Group;
 exports.Text = amino.Text;
+exports.Polygon = amino.Polygon;
 exports.Circle = amino.Circle;
 exports.ImageView = amino.ImageView;
 exports.ParseRGBString = amino.primitives.ParseRGBString;


### PR DESCRIPTION
Fix "TypeError: Cannot read property 'Polygon' of undefined" when trying to create a Polygon in aminogfx-gl
